### PR TITLE
Improve browser audio capture and guidance

### DIFF
--- a/AUDIO_CAPTURE_RESEARCH.md
+++ b/AUDIO_CAPTURE_RESEARCH.md
@@ -90,7 +90,9 @@ const stream = await navigator.mediaDevices.getDisplayMedia(displayMediaOptions)
 4. Нажмите "Share"
 
 ### Firefox:
-❌ Не поддерживает захват аудио
+❌ По умолчанию отключен из-за отсутствия стабильной поддержки.
+При попытке использовать `getDisplayMedia` приложение проверит наличие аудиотрека.
+Подробности см. в [MDN документации](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia#browser_compatibility).
 
 ## 🔧 Тестирование
 
@@ -101,6 +103,10 @@ const stream = await navigator.mediaDevices.getDisplayMedia(displayMediaOptions)
 - Выбрать вкладку с YouTube
 - Отметить "Share tab audio"
 - Проверить визуализацию и воспроизведение
+
+При отсутствии аудиотрека теперь появляется встроенное уведомление
+с подсказкой и кнопкой **Retry**, чтобы пользователь мог повторить
+захват после отметки "Share tab audio".
 
 ## 📚 Источники
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ npm run dev:electron
 - **Audio Monitoring**: Visual feedback of audio levels
 - **Session Logging**: All data is automatically saved and logged
 
+### Browser Audio Capture
+- When sharing a tab or screen, make sure the **"Share tab audio"** checkbox is enabled.
+- If no audio track is captured, the app now shows a prompt with instructions and a **Retry** button.
+- Firefox capture is disabled by default due to limited support; see [MDN compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia#browser_compatibility).
+
 ## 🏛️ Project Structure
 
 ```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useTranscriptionExtended } from "./hooks/transcription";
 import { useAudioRecording } from "./hooks/useAudioRecording";
 import { FeatureFlagPanel } from "./components/FeatureFlagPanel";
 import { AudioSourceSelector } from "./components/AudioSourceSelector";
+import { AudioCaptureInstructions } from "./components";
 
 // Типы для IPC - теперь используется безопасный electronAPI
 declare global {
@@ -130,6 +131,7 @@ export function App() {
         defaultOpen={false}
         position="bottom-right"
       />
+      <AudioCaptureInstructions />
     </>
   );
 }

--- a/src/components/AudioCaptureInstructions.tsx
+++ b/src/components/AudioCaptureInstructions.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+
+interface InstructionEvent {
+  detail: {
+    onRetry: () => void;
+  };
+}
+
+export const AudioCaptureInstructions: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+  const [onRetry, setOnRetry] = useState<() => void>(() => () => {});
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const event = e as InstructionEvent;
+      setOnRetry(() => event.detail.onRetry);
+      setVisible(true);
+    };
+    window.addEventListener('audio-capture-instructions', handler as EventListener);
+    return () => window.removeEventListener('audio-capture-instructions', handler as EventListener);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white rounded-lg p-6 max-w-md text-center">
+        <h2 className="text-xl font-semibold mb-4 text-gray-800">No audio captured</h2>
+        <p className="mb-4 text-gray-700">
+          Please ensure "Share tab audio" is checked and the tab is not muted, then try again.
+        </p>
+        <div className="flex justify-end space-x-2">
+          <button
+            className="px-4 py-2 bg-gray-200 rounded"
+            onClick={() => setVisible(false)}
+          >
+            Cancel
+          </button>
+          <button
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+            onClick={() => {
+              setVisible(false);
+              onRetry();
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@
 // Legacy components (to be refactored)
 export { StartScreen } from './StartScreen';
 export { RecordingScreen } from './RecordingScreen';
+export { AudioCaptureInstructions } from './AudioCaptureInstructions';
 
 // UI Components
 export * from './ui';

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -79,7 +79,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   // └─────────────────────────────────────────────────────────────────────┘
   ENABLE_CHROME_EXTENSION: true,     // Chrome/Edge extension support
   ENABLE_SAFARI_CAPTURE: true,       // Safari screen capture
-  ENABLE_FIREFOX_CAPTURE: true,      // Firefox support
+  ENABLE_FIREFOX_CAPTURE: false,      // Firefox support (disabled by default)
   
   // ┌─────────────────────────────────────────────────────────────────────┐
   // │ UI FEATURES - Comment out to hide UI elements                      │

--- a/src/hooks/useCrossBrowserAudio.ts
+++ b/src/hooks/useCrossBrowserAudio.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { detectBrowser, BrowserInfo } from '../utils/browserDetection';
 import { useSafariCapture } from './useSafariCapture';
+import { getBrowserCaptureConfig } from '../config/browserCaptureConfig';
 
 export type CaptureMethod = 'safari-screen' | 'chrome-extension' | 'generic-screen' | 'unsupported';
 
@@ -110,20 +111,22 @@ export const useCrossBrowserAudio = (options: UseCrossBrowserAudioOptions = {}):
   // Chrome extension state
   const [isExtensionInstalled, setIsExtensionInstalled] = useState(false);
 
-  // Check for Chrome extension
+  // Check for Chrome extension via runtime messaging
   useEffect(() => {
-    if (browser.supportsExtensions) {
-      // Check if extension is installed by looking for injected element
+    if (browser.supportsExtensions && typeof window !== 'undefined' && window.chrome?.runtime?.sendMessage) {
+      const { chrome: chromeCfg } = getBrowserCaptureConfig();
       const checkExtension = () => {
-        const extensionElement = document.getElementById('hrpro-audio-capture-extension');
-        setIsExtensionInstalled(!!extensionElement);
+        try {
+          window.chrome.runtime.sendMessage(chromeCfg.extensionId, { type: 'PING' }, () => {
+            setIsExtensionInstalled(!window.chrome.runtime.lastError);
+          });
+        } catch {
+          setIsExtensionInstalled(false);
+        }
       };
-      
+
       checkExtension();
-      
-      // Re-check periodically in case extension is installed later
-      const interval = setInterval(checkExtension, 2000);
-      
+      const interval = setInterval(checkExtension, 5000);
       return () => clearInterval(interval);
     }
   }, [browser.supportsExtensions]);

--- a/src/services/browserCaptureService.ts
+++ b/src/services/browserCaptureService.ts
@@ -16,13 +16,15 @@
  * ╚════════════════════════════════════════════════════════════════════════════╝
  */
 
-import { 
-  getFeatureFlags, 
+import {
+  getFeatureFlags,
   isFeatureEnabled,
-  getAvailableCaptureMethods 
+  getAvailableCaptureMethods,
+  setFeatureFlag
 } from '../config/featureFlags';
 import { SafariCaptureService } from './safari-capture';
 import { detectBrowser } from '../utils/browserDetection';
+import { getBrowserCaptureConfig } from '../config/browserCaptureConfig';
 
 // ============================================================================
 // SERVICE TYPES
@@ -64,9 +66,13 @@ export class BrowserCaptureService {
   private currentStream: MediaStream | null = null;
   private currentSource: AudioSource = 'microphone';
   private isCapturing: boolean = false;
+  private extensionInstalled = false;
+  private firefoxAudioSupported: boolean | null = null;
 
   constructor() {
     this.initialize();
+    this.checkChromeExtension();
+    this.detectFirefoxAudioSupport();
   }
 
   /**
@@ -129,7 +135,7 @@ export class BrowserCaptureService {
       availableSources: ['microphone'],
       limitations: [],
       requiresExtension: false,
-      extensionInstalled: false,
+      extensionInstalled: this.extensionInstalled,
     };
 
     // Check Safari capabilities
@@ -140,30 +146,27 @@ export class BrowserCaptureService {
       capabilities.limitations.push('Requires screen sharing to capture audio');
     }
 
-    // Check Chrome capabilities
-    if (flags.ENABLE_CHROME_EXTENSION && browser.name.includes('chrome')) {
-      capabilities.requiresExtension = true;
-      // Check if extension is installed (placeholder)
-      capabilities.extensionInstalled = this.checkChromeExtension();
-      
-      if (capabilities.extensionInstalled) {
-        capabilities.canCaptureTab = true;
-        capabilities.canCaptureBrowserAudio = true;
-        capabilities.availableSources.push('browser-tab');
-      } else {
-        capabilities.limitations.push('Chrome extension required for tab audio');
-      }
-      
-      // Screen capture is always available
+    // Chrome and Edge capabilities - tab capture via getDisplayMedia
+    if (browser.name.includes('chrome') || browser.name.includes('edge')) {
+      capabilities.canCaptureTab = true;
       capabilities.canCaptureScreen = true;
-      capabilities.availableSources.push('screen-with-audio');
+      capabilities.canCaptureBrowserAudio = true;
+      capabilities.availableSources.push('browser-tab', 'screen-with-audio');
+
+      if (flags.ENABLE_CHROME_EXTENSION && !this.extensionInstalled) {
+        capabilities.limitations.push('Chrome extension not detected - install for advanced features');
+      }
     }
 
-    // Check Firefox capabilities
-    if (flags.ENABLE_FIREFOX_CAPTURE && browser.name.includes('firefox')) {
-      capabilities.canCaptureScreen = true;
-      capabilities.availableSources.push('screen-with-audio');
-      capabilities.limitations.push('Limited audio capture support');
+    // Firefox capabilities gated by runtime detection
+    if (browser.name.includes('firefox')) {
+      if (flags.ENABLE_FIREFOX_CAPTURE && this.firefoxAudioSupported) {
+        capabilities.canCaptureScreen = true;
+        capabilities.canCaptureBrowserAudio = true;
+        capabilities.availableSources.push('screen-with-audio');
+      } else {
+        capabilities.limitations.push('Firefox audio capture disabled - see MDN for current support');
+      }
     }
 
     // Future: System audio (Phase 2)
@@ -258,10 +261,13 @@ export class BrowserCaptureService {
     const flags = getFeatureFlags();
     const browser = detectBrowser();
 
-    // Проверяем поддержку расширения
-    if (flags.ENABLE_CHROME_EXTENSION && this.checkChromeExtension()) {
-      // TODO: Implement actual Chrome extension communication
-      console.log('[BrowserCapture] Chrome extension detected, but integration pending');
+    // Prompt to install extension when advanced features requested
+    if (flags.ENABLE_CHROME_EXTENSION && !this.extensionInstalled) {
+      if (typeof alert === 'function') {
+        alert('For advanced tab capture features, please install our Chrome extension.');
+      } else {
+        console.warn('[BrowserCapture] Chrome extension not detected');
+      }
     }
 
     // Используем getDisplayMedia как основной метод (работает без расширения!)
@@ -293,7 +299,13 @@ export class BrowserCaptureService {
       // Проверяем аудио
       const audioTracks = stream.getAudioTracks();
       if (audioTracks.length === 0) {
-        throw new Error('No audio captured. Please select a browser tab and enable "Share tab audio".');
+        stream.getTracks().forEach(track => track.stop());
+        window.dispatchEvent(
+          new CustomEvent('audio-capture-instructions', {
+            detail: { onRetry: () => this.startCapture('browser-tab') }
+          })
+        );
+        return { stream: null, source: 'browser-tab', error: new Error('No audio captured') };
       }
 
       // Удаляем видео если не нужно
@@ -371,7 +383,13 @@ export class BrowserCaptureService {
       // Проверяем наличие аудио трека
       const audioTracks = stream.getAudioTracks();
       if (audioTracks.length === 0) {
-        console.warn('[BrowserCapture] No audio track captured. User may not have selected "Share tab audio" option.');
+        stream.getTracks().forEach(track => track.stop());
+        window.dispatchEvent(
+          new CustomEvent('audio-capture-instructions', {
+            detail: { onRetry: () => this.startCapture('screen-with-audio') }
+          })
+        );
+        return { stream: null, source: 'screen-with-audio', error: new Error('No audio captured') };
       } else {
         console.log('[BrowserCapture] Audio track captured successfully:', audioTracks[0].label);
       }
@@ -441,15 +459,67 @@ export class BrowserCaptureService {
   }
 
   /**
-   * Check if Chrome extension is installed
+   * Check if Chrome extension is installed via runtime messaging
    */
-  private checkChromeExtension(): boolean {
-    // TODO: Implement actual extension check
-    // This would involve sending a message to the extension
-    // and checking for a response
-    
-    // For now, return false (not installed)
-    return false;
+  private async checkChromeExtension(): Promise<void> {
+    if (typeof window === 'undefined' || !window.chrome?.runtime?.sendMessage) {
+      this.extensionInstalled = false;
+      return;
+    }
+
+    const { chrome } = getBrowserCaptureConfig();
+    const extensionId = chrome.extensionId;
+
+    await new Promise<void>(resolve => {
+      try {
+        const timer = setTimeout(() => {
+          this.extensionInstalled = false;
+          resolve();
+        }, 1000);
+
+        window.chrome.runtime.sendMessage(extensionId, { type: 'PING' }, () => {
+          clearTimeout(timer);
+          this.extensionInstalled = !window.chrome.runtime.lastError;
+          resolve();
+        });
+      } catch (err) {
+        this.extensionInstalled = false;
+        resolve();
+      }
+    });
+  }
+
+  /**
+   * Detect if Firefox can provide audio in getDisplayMedia
+   */
+  private async detectFirefoxAudioSupport(): Promise<void> {
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.mediaDevices?.getDisplayMedia
+    ) {
+      this.firefoxAudioSupported = false;
+      return;
+    }
+
+    const browser = detectBrowser();
+    if (!browser.name.includes('firefox')) {
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        audio: true,
+        video: true,
+      });
+      const hasAudio = stream.getAudioTracks().length > 0;
+      stream.getTracks().forEach(track => track.stop());
+      this.firefoxAudioSupported = hasAudio;
+      if (hasAudio) {
+        setFeatureFlag('ENABLE_FIREFOX_CAPTURE', true);
+      }
+    } catch {
+      this.firefoxAudioSupported = false;
+    }
   }
 
   /**

--- a/src/test/browserCapture.functional.test.ts
+++ b/src/test/browserCapture.functional.test.ts
@@ -64,7 +64,7 @@ describe('Browser Capture Functional Tests', () => {
       expect(flags.ENABLE_BROWSER_CAPTURE).toBe(true);
       expect(flags.ENABLE_CHROME_EXTENSION).toBe(true);
       expect(flags.ENABLE_SAFARI_CAPTURE).toBe(true);
-      expect(flags.ENABLE_FIREFOX_CAPTURE).toBe(true);
+      expect(flags.ENABLE_FIREFOX_CAPTURE).toBe(false);
     });
 
     it('should allow runtime flag modifications', () => {

--- a/src/test/crossBrowserAudioCapture.test.ts
+++ b/src/test/crossBrowserAudioCapture.test.ts
@@ -247,7 +247,7 @@ describe('Cross-Browser Audio Capture System', () => {
       expect(flags.ENABLE_BROWSER_CAPTURE).toBe(true);
       expect(flags.ENABLE_CHROME_EXTENSION).toBe(true);
       expect(flags.ENABLE_SAFARI_CAPTURE).toBe(true);
-      expect(flags.ENABLE_FIREFOX_CAPTURE).toBe(true);
+      expect(flags.ENABLE_FIREFOX_CAPTURE).toBe(false);
       expect(flags.ENABLE_AUTO_SOURCE_FALLBACK).toBe(true);
     });
 
@@ -380,7 +380,7 @@ describe('Cross-Browser Audio Capture System', () => {
       const capabilities = captureService.getCapabilities();
       
       expect(capabilities.canCaptureScreen).toBe(true);
-      expect(capabilities.requiresExtension).toBe(true);
+      expect(capabilities.requiresExtension).toBe(false);
       expect(capabilities.availableSources).toContain('microphone');
       expect(capabilities.availableSources).toContain('screen-with-audio');
     });
@@ -542,7 +542,7 @@ describe('Cross-Browser Audio Capture System', () => {
       
       // Capabilities should match browser features
       if (browser.supportsExtensions) {
-        expect(capabilities.requiresExtension).toBe(true);
+        expect(capabilities.requiresExtension).toBe(false);
       }
       
       if (browser.supportsScreenCapture) {

--- a/src/test/integration/crossBrowserIntegration.test.ts
+++ b/src/test/integration/crossBrowserIntegration.test.ts
@@ -237,7 +237,7 @@ describe('Cross-Browser Integration Tests', () => {
         name: 'Chrome',
         userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36',
         vendor: 'Google Inc.',
-        expectsExtension: true,
+        expectsExtension: false,
       },
       {
         name: 'Safari',
@@ -255,7 +255,7 @@ describe('Cross-Browser Integration Tests', () => {
         name: 'Edge',
         userAgent: 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
         vendor: 'Microsoft Corporation',
-        expectsExtension: true,
+        expectsExtension: false,
       },
     ];
 
@@ -273,12 +273,7 @@ describe('Cross-Browser Integration Tests', () => {
         const capabilities = service.getCapabilities();
 
         expect(capabilities.availableSources).toContain('microphone');
-        
-        if (browser.expectsExtension) {
-          expect(capabilities.requiresExtension).toBe(true);
-        } else {
-          expect(capabilities.requiresExtension).toBe(false);
-        }
+        expect(capabilities.requiresExtension).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## Summary
- detect Chrome extension via runtime messaging and gate Firefox capture with runtime checks
- show in-app instructions when screen/tab sharing misses audio

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test` *(fails: Cannot use 'in' operator to search for 'getDisplayMedia' in undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fbd4820c8332b34a3ade52d66229